### PR TITLE
[CSR-1543] feat: GHA "failed only" example workflows

### DIFF
--- a/.github/workflows/test-basic-failed-only-or8n.yml
+++ b/.github/workflows/test-basic-failed-only-or8n.yml
@@ -1,0 +1,60 @@
+name: demo.playwright.failed-only-or8n
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test-or8n:
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    container: mcr.microsoft.com/playwright:latest
+    env:
+      CURRENTS_PROJECT_ID: bnsqNa
+      CURRENTS_RECORD_KEY: ${{ secrets.CURRENTS_RECORD_KEY }}
+      CURRENTS_CI_BUILD_ID: or8n-${GITHUB_REPOSITORY}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+      CURRENTS_API_URL: ${{ secrets.CURRENTS_API_URL }}
+      CURRENTS_API_KEY: ${{ secrets.CURRENTS_API_KEY }}
+      CURRENTS_REST_API_URL: ${{ secrets.CURRENTS_REST_API_URL }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      # https://github.com/actions/runner-images/issues/6775
+      - run: |
+          echo "$GITHUB_WORKSPACE"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "18.x"
+
+      - name: Install dependencies
+        run: |
+          npm ci
+          npx playwright install chrome
+          npm install -g @currents/cmd@beta
+
+      - name: Resolve Playwright options
+        run: |
+          PREVIOUS_CI_BUILD_ID="or8n-${GITHUB_REPOSITORY}-${GITHUB_RUN_ID}-$((GITHUB_RUN_ATTEMPT - 1))"
+          EXTRA_PW_FLAGS=""
+
+          if [ ${{ github.run_attempt }} -gt 1 ]; then
+            if npx currents api get-run --pw-last-run --ci-build-id $PREVIOUS_CI_BUILD_ID --output basic/test-results/.last-run.json; then
+              EXTRA_PW_FLAGS="--last-failed"
+            fi
+          fi
+
+          echo "EXTRA_PW_FLAGS=$EXTRA_PW_FLAGS" >> $GITHUB_ENV
+
+      - name: Run Tests
+        working-directory: ./basic
+        run: |
+          COMMAND="npx pwc-p ${{ env.EXTRA_PW_FLAGS }}"
+          echo "Running command: $COMMAND"
+          eval $COMMAND

--- a/.github/workflows/test-basic-failed-only-or8n.yml
+++ b/.github/workflows/test-basic-failed-only-or8n.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       CURRENTS_PROJECT_ID: bnsqNa
       CURRENTS_RECORD_KEY: ${{ secrets.CURRENTS_RECORD_KEY }}
-      CURRENTS_CI_BUILD_ID: or8n-${GITHUB_REPOSITORY}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+      CURRENTS_CI_BUILD_ID: or8n-${{ github.repository }}-${{ github.run_id }}-${{ github.run_attempt }}
       CURRENTS_API_URL: ${{ secrets.CURRENTS_API_URL }}
       CURRENTS_API_KEY: ${{ secrets.CURRENTS_API_KEY }}
       CURRENTS_REST_API_URL: ${{ secrets.CURRENTS_REST_API_URL }}

--- a/.github/workflows/test-basic-failed-only-reporter.yml
+++ b/.github/workflows/test-basic-failed-only-reporter.yml
@@ -1,0 +1,67 @@
+name: demo.playwright.failed-only-reporter
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test-reporter:
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    container: mcr.microsoft.com/playwright:latest
+    env:
+      CURRENTS_PROJECT_ID: bnsqNa
+      CURRENTS_RECORD_KEY: ${{ secrets.CURRENTS_RECORD_KEY }}
+      CURRENTS_CI_BUILD_ID: reporter-${{ github.repository }}-${{ github.run_id }}-${{ github.run_attempt }}
+      CURRENTS_API_URL: ${{ secrets.CURRENTS_API_URL }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      # https://github.com/actions/runner-images/issues/6775
+      - run: |
+          echo "$GITHUB_WORKSPACE"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "18.x"
+
+      - name: Install dependencies
+        run: |
+          npm ci
+          npx playwright install chrome
+          npm install -g @currents/cmd@beta
+
+      - name: Prepare environment & load last run from cache
+        env:
+          DEBUG: "currents,currents:*"
+        run: |
+          npx currents cache get \
+            --preset last-run \
+            --preset-output .preset_output \
+            --matrix-index ${{ matrix.shard }} \
+            --matrix-total ${{ strategy.job-total }}
+          echo "EXTRA_PW_FLAGS=$(cat .preset_output)" >> $GITHUB_ENV
+
+      - name: Run Tests
+        working-directory: ./basic
+        run: |
+          COMMAND="npx playwright test --config playwright.config.reporter.ts $EXTRA_PW_FLAGS"
+          echo "Running command: $COMMAND"
+          $COMMAND
+
+      - name: Cache the last run results
+        env:
+          DEBUG: "currents,currents:*"
+        if: ${{ always() }}
+        run: |
+          npx currents cache set \
+            --preset last-run \
+            --pw-output-dir basic/test-results \
+            --matrix-index ${{ matrix.shard }} \
+            --matrix-total ${{ strategy.job-total }}

--- a/.github/workflows/test-basic-failed-only-shards.yml
+++ b/.github/workflows/test-basic-failed-only-shards.yml
@@ -1,0 +1,67 @@
+name: demo.playwright.failed-only-shards
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test-shards:
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    container: mcr.microsoft.com/playwright:latest
+    env:
+      CURRENTS_PROJECT_ID: bnsqNa
+      CURRENTS_RECORD_KEY: ${{ secrets.CURRENTS_RECORD_KEY }}
+      CURRENTS_CI_BUILD_ID: shards-${{ github.repository }}-${{ github.run_id }}-${{ github.run_attempt }}
+      CURRENTS_API_URL: ${{ secrets.CURRENTS_API_URL }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      # https://github.com/actions/runner-images/issues/6775
+      - run: |
+          echo "$GITHUB_WORKSPACE"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "18.x"
+
+      - name: Install dependencies
+        run: |
+          npm ci
+          npx playwright install chrome
+          npm install -g @currents/cmd@beta
+
+      - name: Prepare environment & load last run from cache
+        env:
+          DEBUG: "currents,currents:*"
+        run: |
+          npx currents cache get \
+            --preset last-run \
+            --preset-output .preset_output \
+            --matrix-index ${{ matrix.shard }} \
+            --matrix-total ${{ strategy.job-total }}
+          echo "EXTRA_PW_FLAGS=$(cat .preset_output)" >> $GITHUB_ENV
+
+      - name: Run Tests
+        working-directory: ./basic
+        run: |
+          COMMAND="npx pwc $EXTRA_PW_FLAGS"
+          echo "Running command: $COMMAND"
+          $COMMAND
+
+      - name: Cache the last run results
+        env:
+          DEBUG: "currents,currents:*"
+        if: ${{ always() }}
+        run: |
+          npx currents cache set \
+            --preset last-run \
+            --pw-output-dir basic/test-results \
+            --matrix-index ${{ matrix.shard }} \
+            --matrix-total ${{ strategy.job-total }}


### PR DESCRIPTION
Notes:
- Project ID is set to - `bnsqNa` (used in other workflows)
- [ ] set `CURRENTS_REST_API_URL` to repository secrets (if not production)
- [ ] set `CURRENTS_API_KEY` to repository secrets
- [x] requires back-end changes to be merged - https://github.com/currents-dev/currents/pull/776
- [ ] requires `@currents/cmd-1.1.0-beta.16+`
- [ ] change the example after the `@currents/cmd-1.1.0` release. Remove the `@beta` from package installation 