### PR TITLE
[CSR-1806] fix: allow math in the previous-ci-build-id template

### DIFF
--- a/.github/workflows/reruns-or8n.yml
+++ b/.github/workflows/reruns-or8n.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           or8n: true
           # debug: true
-          # previous-ci-build-id: default is ${{ github.repository }}-${{ github.run_id }}-${{ github.run_attempt - 1 }}
+          # previous-ci-build-id: default is ${{ github.repository }}-${{ github.run_id }}-<%= ${{ github.run_attempt }} - 1 %>
           pw-output-dir: basic/test-results
 
       - name: Playwright Tests


### PR DESCRIPTION
- Use lodash template syntax to minus one from the run-attempt