### PR TITLE
chore: update argos screenshot settings

### DIFF
--- a/argos/playwright.config.ts
+++ b/argos/playwright.config.ts
@@ -24,8 +24,8 @@ const config: PlaywrightTestConfig = {
   use: {
     actionTimeout: 0,
     trace: "on",
-    video: "on",
-    screenshot: "on",
+    video: "retain-on-failure",
+    screenshot: "only-on-failure",
   },
 
   projects: [


### PR DESCRIPTION
- Only keep normal playwright screenshots on failure
-  Based on user feedback, the screenshots that don't use the argos fixture still get sent to argos, but are less useful with their tools. Ideally just keep the failures, and otherwise users should use the argos screenshot tools.